### PR TITLE
Allow custom Abstraction implementation.

### DIFF
--- a/src/fabric/java/com/moulberry/mixinconstraints/FabricAbstractionsImpl.java
+++ b/src/fabric/java/com/moulberry/mixinconstraints/FabricAbstractionsImpl.java
@@ -37,4 +37,9 @@ public class FabricAbstractionsImpl extends Abstractions {
 			throw new RuntimeException(e);
 		}
 	}
+
+	@Override
+	public String getPlatformName() {
+		return "Fabric";
+	}
 }

--- a/src/forge/java/com/moulberry/mixinconstraints/ForgeAbstractionsImpl.java
+++ b/src/forge/java/com/moulberry/mixinconstraints/ForgeAbstractionsImpl.java
@@ -32,4 +32,9 @@ public class ForgeAbstractionsImpl extends Abstractions {
 
 		return new Restriction(min, true, max, true).containsVersion(currentVersion);
 	}
+
+	@Override
+	public String getPlatformName() {
+		return "Forge";
+	}
 }

--- a/src/main/java/com/moulberry/mixinconstraints/MixinConstraints.java
+++ b/src/main/java/com/moulberry/mixinconstraints/MixinConstraints.java
@@ -1,6 +1,7 @@
 package com.moulberry.mixinconstraints;
 
 import com.moulberry.mixinconstraints.checker.AnnotationChecker;
+import com.moulberry.mixinconstraints.util.Abstractions;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.slf4j.Logger;
@@ -45,6 +46,14 @@ public class MixinConstraints {
         return shouldApplyMixin(mixinClassName);
     }
 
+    public static String getLoaderName() {
+        return Abstractions.getLoaderName();
+    }
+
+    /**
+     * @deprecated use {@link #getLoaderName()} instead.
+     */
+    @Deprecated
     public static Loader getLoader() {
         if (loader == null) {
             loader = findLoader();
@@ -54,28 +63,16 @@ public class MixinConstraints {
     }
 
     private static Loader findLoader() {
-        if (doesClassExist("net.neoforged.fml.loading.FMLLoader")) {
-            return Loader.NEOFORGE;
-        } else if (doesClassExist("net.minecraftforge.fml.loading.FMLLoader")) {
-            return Loader.FORGE;
-        } else if (doesClassExist("net.fabricmc.loader.api.FabricLoader")) {
-            return Loader.FABRIC;
-        }
-
-        throw new RuntimeException("Could not determine loader");
-    }
-
-    private static boolean doesClassExist(String className) {
-        try {
-            Class.forName(className, false, MixinConstraints.class.getClassLoader());
-            return true;
-        } catch (ClassNotFoundException ignored) {
-            return false;
-        }
+        return switch (Abstractions.getLoaderName()) {
+            case "Forge" -> Loader.FORGE;
+            case "NeoForge" -> Loader.NEOFORGE;
+            case "Fabric" -> Loader.FABRIC;
+            default -> Loader.CUSTOM;
+        };
     }
 
     public enum Loader {
-        FORGE, NEOFORGE, FABRIC;
+        FORGE, NEOFORGE, FABRIC, CUSTOM;
 
         @Override
         public String toString() {
@@ -83,6 +80,7 @@ public class MixinConstraints {
                 case FORGE -> "Forge";
                 case NEOFORGE -> "NeoForge";
                 case FABRIC -> "Fabric";
+                case CUSTOM -> getLoaderName();
             };
         }
     }

--- a/src/main/java/com/moulberry/mixinconstraints/util/Abstractions.java
+++ b/src/main/java/com/moulberry/mixinconstraints/util/Abstractions.java
@@ -5,17 +5,33 @@ import com.moulberry.mixinconstraints.MixinConstraints;
 public abstract class Abstractions {
 	private static Abstractions instance = null;
 
+    private static boolean doesClassExist(String className) {
+        try {
+            Class.forName(className, false, MixinConstraints.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
     private static Abstractions getInstance() {
         if (instance == null) {
+            String name = System.getProperty("mixinconstraints.abstraction");
+            if (name == null || name.isEmpty()) {
+                if (doesClassExist("net.neoforged.fml.loading.FMLLoader")) {
+                    name = "com.moulberry.mixinconstraints.NeoForgeAbstractionsImpl";
+                } else if (doesClassExist("net.minecraftforge.fml.loading.FMLLoader")) {
+                    name = "com.moulberry.mixinconstraints.ForgeAbstractionsImpl";
+                } else if (doesClassExist("net.fabricmc.loader.api.FabricLoader")) {
+                    name = "com.moulberry.mixinconstraints.FabricAbstractionsImpl";
+                } else {
+                    throw new RuntimeException("Could not determine loader");
+                }
+            }
             try {
-                String name = switch (MixinConstraints.getLoader()) {
-                    case FORGE -> "com.moulberry.mixinconstraints.ForgeAbstractionsImpl";
-                    case NEOFORGE -> "com.moulberry.mixinconstraints.NeoForgeAbstractionsImpl";
-                    case FABRIC -> "com.moulberry.mixinconstraints.FabricAbstractionsImpl";
-                };
-                instance = (Abstractions) Class.forName(name).getDeclaredConstructor().newInstance();
+                instance = Class.forName(name).asSubclass(Abstractions.class).getDeclaredConstructor().newInstance();
             } catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException("Failed to load " + name, e);
             }
         }
         return instance;
@@ -37,7 +53,13 @@ public abstract class Abstractions {
 		return instance.isVersionInRange(version, minVersion, maxVersion);
 	}
 
+    public static String getLoaderName() {
+        Abstractions instance = getInstance();
+        return instance.getPlatformName();
+    }
+
 	protected abstract boolean isDevEnvironment();
 	protected abstract String getModVersion(String modId);
 	protected abstract boolean isVersionInRange(String version, String minVersion, String maxVersion);
+    protected abstract String getPlatformName();
 }

--- a/src/neoforge/java/com/moulberry/mixinconstraints/NeoForgeAbstractionsImpl.java
+++ b/src/neoforge/java/com/moulberry/mixinconstraints/NeoForgeAbstractionsImpl.java
@@ -32,4 +32,9 @@ public class NeoForgeAbstractionsImpl extends Abstractions {
 
 		return new Restriction(min, true, max, true).containsVersion(currentVersion);
 	}
+
+	@Override
+	public String getPlatformName() {
+		return "NeoForge";
+	}
 }

--- a/testmod/src/main/java/com/moulberry/mixinconstraints/testmod/TestMod.java
+++ b/testmod/src/main/java/com/moulberry/mixinconstraints/testmod/TestMod.java
@@ -12,7 +12,7 @@ public final class TestMod {
 
 	public static void init() {
 		LOGGER.info("init() called");
-		LOGGER.info("Platform: {}", MixinConstraints.getLoader());
+		LOGGER.info("Platform: {}", MixinConstraints.getLoaderName());
 
         if (!modLoadedTruePassed) {
             throw new Error("TestIfModLoadedTrue failed!");


### PR DESCRIPTION
This is the first of 2 PRs, this one allows custom MixinExtras implementation classes.

Additionally, it can be used by compatibility layers like KiltMC to set an already existing backend:
`System.setProperty("mixinconstraints.abstraction", "com.moulberry.mixinconstraints.FabricAbstractionsImpl")`
(KitlMC is a mod to load forge mods on Fabric, so it would make MixinConstraints not pick the forge backend on Fabric)

I also had to deprecate `getLoader()` as now custom mod loaders can be used, this APIs make a lot less sense.
I added `getLoaderName()` API as a replacement for the `getLoader()` API.

Close: #8 